### PR TITLE
Uptime sensor unit of time changed to Seconds

### DIFF
--- a/custom_components/watergate/sensor.py
+++ b/custom_components/watergate/sensor.py
@@ -200,7 +200,7 @@ async def async_setup_entry(
             coordinator,
             UPTIME_SENSOR_NAME,
             UPTIME_ENTITY_NAME,
-            UnitOfTime.MILLISECONDS,
+            UnitOfTime.SECONDS,
             SensorDeviceClass.DURATION,
             lambda data: data.state.uptime if data.state else None,
             EntityCategory.DIAGNOSTIC,


### PR DESCRIPTION
API is returning total uptime in seconds not milliseconds. This aligns the sensor in HA to the correct units.